### PR TITLE
refine php compatibility check > 5.3.6 < 7

### DIFF
--- a/lib/compat.php
+++ b/lib/compat.php
@@ -6,7 +6,11 @@
  * @return boolean
  */
 function ppi_php_compatible() {
-    return function_exists('stream_supports_lock');
+    if (version_compare('5.3.6', PHP_VERSION) === 1) {
+        return false;
+    }
+
+    return PHP_MAJOR_VERSION < 7;
 }
 
 /**

--- a/views/pre-install.php
+++ b/views/pre-install.php
@@ -9,6 +9,14 @@
     <li class="good">
         Your PHP version is compatible.
     </li>
+    <?php } else if (defined('PHP_MAJOR_VERSION') && PHP_MAJOR_VERSION === 7) { ?>
+    <li class="bad">
+        Your PHP version is not compatible.
+        <span>
+            ProPhoto 6 is <strong>not yet</strong> compatible with <code>PHP 7</code>.
+            It will be very soon, but for now, you'll need to downgrade to PHP 5.6 or 5.5.
+        </span>
+    </li>
     <?php } else { ?>
     <li class="bad">
         Your PHP version is not compatible.


### PR DESCRIPTION
I think I got the `version_compare()` bool test right.  Here's a screenshot of me making sure I know how to use it, for you to double-check:

![2016-04-21_11-54-17](https://cloud.githubusercontent.com/assets/7050938/14715773/27aaa874-07b8-11e6-909a-9fd9f4d64e7e.png)
