### PR TITLE
Fix display of non-test-drive theme name everywhere

### DIFF
--- a/lib/admin_page.php
+++ b/lib/admin_page.php
@@ -63,7 +63,7 @@ function ppi_render_admin_page() {
 function ppi_render_test_driving_page() {
     $disableTestDriveUrl = admin_url('?ppi_disable_test_drive=1');
     $goLiveUrl = admin_url('themes.php?activated=true&ppi_go_live=1');
-    $nonTestDriveTheme = ppi_get_theme_name(get_option('template'));
+    $nonTestDriveTheme = ppi_get_non_test_drive_theme_name();
     include(PPI_DIR . '/views/test-driving.php');
 }
 

--- a/lib/theme.php
+++ b/lib/theme.php
@@ -70,6 +70,15 @@ function ppi_get_theme_name($template = null) {
 }
 
 /**
+ * Get the theme name NOT being test-driven
+ *
+ * @return string
+ */
+function ppi_get_non_test_drive_theme_name() {
+    return ppi_get_theme_name(get_option('template'));
+}
+
+/**
  * Get a nonced link for activating P6
  *
  * @return string

--- a/pp-installer.php
+++ b/pp-installer.php
@@ -4,7 +4,7 @@ Plugin Name: ProPhoto 6 Installer
 Plugin URI: https://github.com/netrivet/prophoto-installer-plugin
 Description: Theme installer plugin for ProPhoto version 6. Checks server compatibility, auto-registers, and allows test-driving P6 while safely keeping another theme active.
 Author: ProPhoto
-Version: 6.0.3
+Version: 6.0.4
 Author URI: https://www.prophoto.com/
 License: MIT
  */

--- a/views/installed.php
+++ b/views/installed.php
@@ -24,7 +24,7 @@
 <p class="narrow">
     If you choose to test-drive ProPhoto 6, only logged-in admin users will have P6
     as their active theme.  All other users will see your active theme:
-    <b><?php echo ppi_get_theme_name(); ?></b>. This allows you to work on your
+    <b><?php echo ppi_get_non_test_drive_theme_name(); ?></b>. This allows you to work on your
     conversion to P6 and your updated responsive design in privacy, until you're ready
     to go live.  In the meantime, all of your normal web visitors will see your
     existing design and functionality.

--- a/views/notice-test-driving.php
+++ b/views/notice-test-driving.php
@@ -2,7 +2,7 @@
     <p style="margin: 0.75em">
         You are currently <b style="text-decoration: underline;">test-driving ProPhoto 6</b>.
         Logged-in users can see and customize P6, but all normal site visitors will see
-        your site with the <b><?php echo ppi_get_theme_name(); ?> theme</b> active.
+        your site with the <b><?php echo ppi_get_non_test_drive_theme_name(); ?> theme</b> active.
         <a href="<?php echo ppi_get_admin_page_url(); ?>">Click here</a> for more options.
     </p>
 </div>

--- a/views/test-driving.php
+++ b/views/test-driving.php
@@ -28,7 +28,7 @@
 <p class="narrow">
     When test-driving ProPhoto 6, only logged-in admin users will have P6
     as their active theme.  All other users will see your active theme:
-    <b><?php echo ppi_get_theme_name(); ?></b>. This allows you to work on your
+    <b><?php echo $nonTestDriveTheme; ?></b>. This allows you to work on your
     conversion to P6 and your updated responsive design in privacy, until you're ready
     to go live.  In the meantime, all of your normal web visitors will see your
     existing design and functionality.


### PR DESCRIPTION
Fixes a problem a customer pointed out to Steve, where the test-drive plugin displays that P6 is also the theme being shown to non-logged in users:

![2016-08-10_10-59-46](https://cloud.githubusercontent.com/assets/7050938/17576842/340eb012-5f45-11e6-87ef-3bf4e4bc1e48.png)
