### PR TITLE
Bootstrap js flag for customizer

### DIFF
--- a/lib/functions.php
+++ b/lib/functions.php
@@ -95,3 +95,12 @@ function ppi_manage_designs_bootstrap() {
 
   echo "<script>window.testDriveLiveTheme = $themeData;</script>";
 }
+
+/**
+ * Bootstrap js data from ProPhoto customizer
+ *
+ * @return void
+ */
+function ppi_customizer_bootstrap() {
+  echo "<script>window.testDriving = true;</script>";
+}

--- a/lib/test_drive.php
+++ b/lib/test_drive.php
@@ -33,6 +33,7 @@ function ppi_test_drive_init() {
     if (ppi_test_driving()) {
         add_filter('all_admin_notices', 'ppi_notice_test_driving');
         add_action('admin_head', 'ppi_manage_designs_bootstrap');
+        add_action('pp_customizer_head', 'ppi_customizer_bootstrap');
     }
 
     ppi_handle_test_drive_changes();


### PR DESCRIPTION
This gives the customizer knowledge that P6 is being test-driven, so it can modify the design-switcher styling and tooltips accordingly.