### PR TITLE
Update recommended PHP version language to push 7.x

### DIFF
--- a/css/admin.css
+++ b/css/admin.css
@@ -19,7 +19,7 @@
     margin: 4px 0 12px 33px;
     font-size: 13px;
     max-width: 760px;
-    line-height: 16px;
+    line-height: 19px;
     color: #A63939;
 }
 
@@ -47,7 +47,7 @@
 
 #pp-recommendations {
     font-size: 16px;
-    line-height: 1.25em;
+    line-height: 1.55em;
     padding-left: 0.75em;
     color: #B68310;
 }

--- a/lib/admin_page.php
+++ b/lib/admin_page.php
@@ -84,7 +84,7 @@ function ppi_render_p6_installed_page() {
  * @return void
  */
 function ppi_render_recommendations() {
-    $phpOutdated = version_compare('5.5', PHP_VERSION) === 1;
+    $phpOutdated = version_compare('5.6', PHP_VERSION) === 1;
     $memoryLimit = (int) ini_get('memory_limit');
     $memoryLimitLow = $memoryLimit < 256;
     $missingImagick = !class_exists('Imagick');

--- a/views/pre-install.php
+++ b/views/pre-install.php
@@ -15,9 +15,11 @@
         <span>
             Please contact your webhost tech support and have them upgrade your
             server to use a faster, safer, and more modern version of PHP.
-            Tell them you need to be running at least on PHP version 5.3.6, but 5.4,
-            5.5, and 5.6 are even better, because each newer version gets faster
-            and more secure.
+            Tell them you need to be running at least PHP version 5.3.6, but
+            5.6 or higher is even better, because each newer version gets faster
+            and more secure. If your host offers PHP 7.0 or 7.1 make sure you get
+            on one of those versions, as they are nearly twice as fast as older
+            versions.
         </span>
     </li>
     <?php } ?>

--- a/views/recommendations.php
+++ b/views/recommendations.php
@@ -14,15 +14,14 @@
         <li>
             Your PHP version is out of date
             <span>
-                While it is compatible with P6, the version of <code>PHP</code> (the
-                computer code langage that powers WordPress and ProPhoto) your host
-                is running is fairly outdated. You are running PHP <code>
-                <?php echo PHP_MAJOR_VERSION . '.' . PHP_MINOR_VERSION; ?></code>,
-                which is slower and less secure than modern versions. We recommend
-                that you call your webhost and ask them to upgrade your PHP version
-                to <code>5.5</code> or <code>5.6</code>. Getting updated to the highest
-                version of PHP you can should make your site run faster, be more secure,
-                and also will guarantee compatibility with future versions of ProPhoto.
+                Your PHP version:
+                <code><?php echo PHP_MAJOR_VERSION . '.' . PHP_MINOR_VERSION; ?></code>,
+                is technically compatible, but is insecure and outdated. We recommend
+                that you call your webhost and ask them to upgrade your PHP to at
+                least <code>5.6</code>, or ideally <code>7.0</code> or <code>7.1</code>.
+                Version <code>7.0</code> and higher run <em>nearly twice as fast</em>
+                as older versions, and are more secure, so it's definitely worth a quick
+                call to get updated.
             </span>
         </li>
         <?php } ?>


### PR DESCRIPTION
Also, shows recommendation for anything lower than `5.6` now, instead of `5.5`.

Fixes https://github.com/netrivet/zendesk-embedded-app/issues/92.